### PR TITLE
Added missing inclusion to avoid building error.

### DIFF
--- a/libfuzzer_integration/llvm_11.0.1/llvm/utils/benchmark/src/benchmark_register.h
+++ b/libfuzzer_integration/llvm_11.0.1/llvm/utils/benchmark/src/benchmark_register.h
@@ -2,6 +2,7 @@
 #define BENCHMARK_REGISTER_H
 
 #include <vector>
+#include <limits>
 
 #include "check.h"
 

--- a/libfuzzer_integration/llvm_11.0.1/llvm/utils/benchmark/src/benchmark_register.h
+++ b/libfuzzer_integration/llvm_11.0.1/llvm/utils/benchmark/src/benchmark_register.h
@@ -1,8 +1,8 @@
 #ifndef BENCHMARK_REGISTER_H
 #define BENCHMARK_REGISTER_H
 
-#include <vector>
 #include <limits>
+#include <vector>
 
 #include "check.h"
 


### PR DESCRIPTION
Building the llvm-11 included with k-scheduler on Ubuntu 22.04 will fail due to a missing inclusion.

```
/K-Scheduler/libfuzzer_integration/llvm_11.0.1/llvm/utils/benchmark/src/benchmark_register.h:17:30: error: 'numeric_limits' is not a member of 'std'
   17 |   static const T kmax = std::numeric_limits<T>::max();
      |                              ^~~~~~~~~~~~~~
/K-Scheduler/libfuzzer_integration/llvm_11.0.1/llvm/utils/benchmark/src/benchmark_register.h:17:46: error: expected primary-expression before '>' token
   17 |   static const T kmax = std::numeric_limits<T>::max();
      |                                              ^
/K-Scheduler/libfuzzer_integration/llvm_11.0.1/llvm/utils/benchmark/src/benchmark_register.h:17:49: error: '::max' has not been declared; did you mean 'std::max'?
   17 |   static const T kmax = std::numeric_limits<T>::max();
      |                                                 ^~~
      |                                                 std::max

```

This is fixed on a later version of LLVM (https://reviews.llvm.org/rGb498303066a63a203d24f739b2d2e0e56dca70d1). This PR ports the fix to the version k-scheduler uses.